### PR TITLE
Use remote docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2 - 01/09/2021
+
+- Use Docker image with dependencies pre-loaded
+
 ## v1 - 01/06/2021
 
 - Initial Implementation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,4 @@
-FROM uochan/antq AS BASE
-
-LABEL "com.github.actions.name"="Clojure Dependency Update Action"
-LABEL "com.github.actions.description"="A simple GitHub Actions to create Pull Requests for outdated tools.deps dependencies"
-LABEL "com.github.actions.color"="purple"
-LABEL "com.github.actions.icon"="git-pull-request"
-
-LABEL "repository"="https://github.com/nnichols/clojure-dependency-update-action"
-LABEL "homepage"="https://github.com/nnichols"
-LABEL "maintainer"="Nick Nichols <nichols1991@gmail.com>"
-
-RUN apt update -y
-RUN apt install --no-install-recommends -y gnupg2 software-properties-common
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-RUN apt-add-repository https://cli.github.com/packages
-RUN apt update -y
-RUN apt install -y gh git
+FROM nnichols/clojure-dependency-update-action
 
 COPY dependency-check.sh /dependency-check.sh
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ jobs:
 ## Acknowledgements
 
 Special thanks to [Chad Taylor](https://github.com/tessellator) for figuring out the initial bash script this is based on.
+
+## Licensing
+
+Copyright © 2021 [Nick Nichols](https://nnichols.github.io/)
+
+Distributed under the [MIT License](https://github.com/nnichols/clojure-dependency-update-action/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Check deps
-      uses: nnichols/clojure-dependency-update-action@v1
+      uses: nnichols/clojure-dependency-update-action@v2
       with:
         github-token: ${{ secrets.github_token }}
 ```


### PR DESCRIPTION
Changes proposed in this merge request:
- Updates: Use a Docker image that already has dependencies downloaded

