### PR TITLE
Upgrade deps on each dir in $DIRECTORY/deps.edn

### DIFF
--- a/dependency-check.sh
+++ b/dependency-check.sh
@@ -23,44 +23,52 @@ done
 PREFETCH=$(clojure -Stree -Sdeps '{:deps {antq/antq {:mvn/version "RELEASE"}}}')
 UPGRADES=$(clojure -Sdeps '{:deps {antq/antq {:mvn/version "RELEASE"}}}' -m antq.core --reporter=format --error-format="{{name}},{{version}},{{latest-version}}" $EXCLUDES $DIRECTORIES $SKIPS | sed '/Failed to fetch/d' | sed '/Unable to fetch/d' | sed '/Logging initialized/d')
 
+if [ -z "${DIRECTORY}" ]; then
+    DIRECTORY="."
+fi
+
 if [ $BATCH = 'true' ]; then
   BRANCH_NAME="dependencies/clojure/$(date +"%Y-%m-%d-%H-%M-%S")"
   git checkout -b $BRANCH_NAME
-  for upgrade in $UPGRADES; do
-    IFS=',' temp=($upgrade)
-    DEP_NAME=${temp[0]}
-    OLD_VERSION=${temp[1]}
-    NEW_VERSION=${temp[2]}
-    echo "Updating" $DEP_NAME "version" $OLD_VERSION "to" $NEW_VERSION
-    ESCAPED_DEP_NAME=`echo $DEP_NAME | sed 's/\//\\\\\//'`
-    sed -e "/$ESCAPED_DEP_NAME/s/$OLD_VERSION/$NEW_VERSION/" deps.edn > deps2.edn
-    mv deps2.edn deps.edn
-    git add .
-    git commit -m "Bump $DEP_NAME from $OLD_VERSION to $NEW_VERSION"
+  for dir in $DIRECTORY; do
+      for upgrade in $UPGRADES; do
+          IFS=',' temp=($upgrade)
+          DEP_NAME=${temp[0]}
+          OLD_VERSION=${temp[1]}
+          NEW_VERSION=${temp[2]}
+          echo "Updating" $DEP_NAME "version" $OLD_VERSION "to" $NEW_VERSION
+          ESCAPED_DEP_NAME=`echo $DEP_NAME | sed 's/\//\\\\\//'`
+          sed -e "/$ESCAPED_DEP_NAME/s/$OLD_VERSION/$NEW_VERSION/" $dir/deps.edn > $dir/deps2.edn
+          mv $dir/deps2.edn $dir/deps.edn
+          git add .
+          git commit -m "Bump $DEP_NAME from $OLD_VERSION to $NEW_VERSION"
+      done
   done
   git push -u "https://$GITHUB_ACTOR:$TOKEN@github.com/$GITHUB_REPOSITORY.git" $BRANCH_NAME
   gh pr create --fill --head $BRANCH_NAME --base $BRANCH
   echo
   git checkout $BRANCH
 else
-  for upgrade in $UPGRADES; do
-    IFS=',' temp=($upgrade)
-    DEP_NAME=${temp[0]}
-    OLD_VERSION=${temp[1]}
-    NEW_VERSION=${temp[2]}
-    BRANCH_NAME="dependencies/clojure/$DEP_NAME-$NEW_VERSION"
-    echo "Updating" $DEP_NAME "version" $OLD_VERSION "to" $NEW_VERSION
-    git checkout -b $BRANCH_NAME
-    if [[ $? == 0 ]]; then
-      ESCAPED_DEP_NAME=`echo $DEP_NAME | sed 's/\//\\\\\//'`
-      sed -e "/$ESCAPED_DEP_NAME/s/$OLD_VERSION/$NEW_VERSION/" deps.edn > deps2.edn
-      mv deps2.edn deps.edn
-      git add .
-      git commit -m "Bump $DEP_NAME from $OLD_VERSION to $NEW_VERSION"
-      git push -u "https://$GITHUB_ACTOR:$TOKEN@github.com/$GITHUB_REPOSITORY.git" $BRANCH_NAME
-      gh pr create --fill --head $BRANCH_NAME --base $BRANCH
-      echo
-      git checkout $BRANCH
-    fi
+  for dir in $DIRECTORY; do
+      for upgrade in $UPGRADES; do
+          IFS=',' temp=($upgrade)
+          DEP_NAME=${temp[0]}
+          OLD_VERSION=${temp[1]}
+          NEW_VERSION=${temp[2]}
+          BRANCH_NAME="dependencies/clojure/$DEP_NAME-$NEW_VERSION"
+          echo "Updating" $DEP_NAME "version" $OLD_VERSION "to" $NEW_VERSION
+          git checkout -b $BRANCH_NAME
+          if [[ $? == 0 ]]; then
+              ESCAPED_DEP_NAME=`echo $DEP_NAME | sed 's/\//\\\\\//'`
+              sed -e "/$ESCAPED_DEP_NAME/s/$OLD_VERSION/$NEW_VERSION/" $dir/deps.edn > $dir/deps2.edn
+              mv $dir/deps2.edn $dir/deps.edn
+              git add .
+              git commit -m "Bump $DEP_NAME from $OLD_VERSION to $NEW_VERSION"
+              git push -u "https://$GITHUB_ACTOR:$TOKEN@github.com/$GITHUB_REPOSITORY.git" $BRANCH_NAME
+              gh pr create --fill --head $BRANCH_NAME --base $BRANCH
+              echo
+              git checkout $BRANCH
+          fi
+      done
   done
 fi


### PR DESCRIPTION
Changes proposed in this merge request:
- Additions:
  * If `$DIRECTORY` is set, update `$dir/deps.edn` rather than `./deps.edn`.

This feature didn't work as I expected it to. If a list of space separated directories is supplied for `antq-action` to search for project files, this project still tries to update `./deps.edn` in the root of the repo. In our case, a repo can contain a number of sub-directories that contain `deps.edn` or `pom.xml`, etc., files.

This PR proposes to update a `deps.edn` file in each of the directories listed in `$DIRECTORY`.

Perhaps a more thorough approach could be to find all `deps.edn` files in the directory tree, and attempt to update all of them?