### PR TITLE
CDUA-7: Better monorepo support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4 - 01/29/2022
+
+- Dependency update commit messages now link to the github diff between the old and new version.
+- Utilize antq instead of sed for updating dependencies
+- Fix multi-directory support
+
 ## v3 - 01/30/2021
 
 - Enable a batch update mode

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
 
 ```yml
 
-name: clojure-dependency-update-action Batch Tests
+name: Batch Dependency Update
 
 on: workflow_dispatch
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ Special thanks to [Chad Taylor](https://github.com/tessellator) for figuring out
 
 ## Licensing
 
-Copyright © 2021 [Nick Nichols](https://nnichols.github.io/)
+Copyright © 2021-2022 [Nick Nichols](https://nnichols.github.io/)
 
 Distributed under the [MIT License](https://github.com/nnichols/clojure-dependency-update-action/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Clojure Dependency Update Action
 
-A simple GitHub action to create Pull Requests for your out-of-date tools.deps dependencies.
+A simple GitHub action to create Pull Requests for your out-of-date dependencies in clojure projects.
+This action can automatically update the following dependency files:
+
+- [deps.edn](https://github.com/clojure/tools.deps.alpha)
+- [shadow-cljs.edn](https://github.com/thheller/shadow-cljs)
+- [project.clj](https://github.com/technomancy/leiningen)
+- [build.boot](https://github.com/boot-clj/boot)
+- [pom.xml](https://github.com/apache/maven)
 
 This action uses [antq](https://github.com/liquidz/antq) to check dependencies.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This action uses [antq](https://github.com/liquidz/antq) to check dependencies.
 
 ## Sample Usage
 
+### Basic
+
 ```yml
 name: Clojure Dependency Checking
 
@@ -18,12 +20,40 @@ jobs:
 
     steps:
     - name: Checkout Latest Commit
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.4
 
     - name: Check deps
-      uses: nnichols/clojure-dependency-update-action@v3
+      uses: nnichols/clojure-dependency-update-action@v4
       with:
         github-token: ${{ secrets.github_token }}
+```
+
+### Advanced
+
+```yml
+
+name: clojure-dependency-update-action Batch Tests
+
+on: workflow_dispatch
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Latest Commit
+      uses: actions/checkout@v2.3.4
+
+    - name: Check deps
+      uses:  nnichols/clojure-dependency-update-action@v4
+      with:
+        github-token: ${{ secrets.github_token }}
+        git-username: nnichols
+        skips: "pom"
+        batch: "true"
+        branch: "main"
+        directories: "cli web"
 ```
 
 ## Supported Arguments

--- a/dependency-check.sh
+++ b/dependency-check.sh
@@ -25,10 +25,10 @@ for skip in $SKIP; do
 done
 
 PREFETCH=$(clojure -Stree -Sdeps '{:deps {antq/antq {:mvn/version "RELEASE"}}}')
-FORMATTER="--reporter=format --error-format=\"{{name}},{{version}},{{latest-version}},{{diff-url}},{{file}}\""
+FORMATTER="--reporter=format --error-format=\"{{name}},{{version}},{{latest-version}},{{diff-url}}\""
 UPGRADE_CMD="clojure -Sdeps '{:deps {antq/antq {:mvn/version \"RELEASE\"}}}' -m antq.core ${FORMATTER} ${EXCLUDES} ${DIRECTORIES} ${SKIPS}"
 UPGRADE_LIST=$(eval ${UPGRADE_CMD})
-UPGRADES=$(echo ${UPGRADE_LIST} | sed '/Failed to fetch/d' | sed '/Unable to fetch/d' | sed '/Logging initialized/d')
+UPGRADES=$(echo ${UPGRADE_LIST} | sed '/Failed to fetch/d' | sed '/Unable to fetch/d' | sed '/Logging initialized/d' | sort -u)
 UPDATE_TIME=$(date +"%Y-%m-%d-%H-%M-%S")
 
 for upgrade in $UPGRADES; do

--- a/dependency-check.sh
+++ b/dependency-check.sh
@@ -10,6 +10,10 @@ for artifact in $EXCLUDE; do
     EXCLUDES="${EXCLUDES} --exclude=${artifact}"
 done
 
+if [ -z "${DIRECTORY}" ]; then
+    DIRECTORY="."
+fi
+
 DIRECTORIES=""
 for directory in $DIRECTORY; do
     DIRECTORIES="${DIRECTORIES} --directory=${directory}"
@@ -26,21 +30,12 @@ UPGRADES=$(clojure -Sdeps '{:deps {antq/antq {:mvn/version "RELEASE"}}}' -m antq
 if [ $BATCH = 'true' ]; then
   BRANCH_NAME="dependencies/clojure/$(date +"%Y-%m-%d-%H-%M-%S")"
   git checkout -b $BRANCH_NAME
-  for upgrade in $UPGRADES; do
-    IFS=',' temp=($upgrade)
-    DEP_NAME=${temp[0]}
-    OLD_VERSION=${temp[1]}
-    NEW_VERSION=${temp[2]}
-    echo "Updating" $DEP_NAME "version" $OLD_VERSION "to" $NEW_VERSION
-    ESCAPED_DEP_NAME=`echo $DEP_NAME | sed 's/\//\\\\\//'`
-    sed -e "/$ESCAPED_DEP_NAME/s/$OLD_VERSION/$NEW_VERSION/" deps.edn > deps2.edn
-    mv deps2.edn deps.edn
-    git add .
-    git commit -m "Bump $DEP_NAME from $OLD_VERSION to $NEW_VERSION"
-  done
+  echo "Updating all dependencies"
+  clojure -Sdeps '{:deps {antq/antq {:mvn/version "RELEASE"}}}' -m antq.core --upgrade --force $EXCLUDES $DIRECTORIES $SKIPS
+  git add .
+  git commit -m "Update all outdated dependencies"
   git push -u "https://$GITHUB_ACTOR:$TOKEN@github.com/$GITHUB_REPOSITORY.git" $BRANCH_NAME
   gh pr create --fill --head $BRANCH_NAME --base $BRANCH
-  echo
   git checkout $BRANCH
 else
   for upgrade in $UPGRADES; do
@@ -52,9 +47,7 @@ else
     echo "Updating" $DEP_NAME "version" $OLD_VERSION "to" $NEW_VERSION
     git checkout -b $BRANCH_NAME
     if [[ $? == 0 ]]; then
-      ESCAPED_DEP_NAME=`echo $DEP_NAME | sed 's/\//\\\\\//'`
-      sed -e "/$ESCAPED_DEP_NAME/s/$OLD_VERSION/$NEW_VERSION/" deps.edn > deps2.edn
-      mv deps2.edn deps.edn
+      clojure -Sdeps '{:deps {antq/antq {:mvn/version "RELEASE"}}}' -m antq.core --upgrade --force --directory=${dir} --focus=${DEP_NAME} || echo "Cannot update $DEP_NAME. Continuing" && git checkout $BRANCH && continue
       git add .
       git commit -m "Bump $DEP_NAME from $OLD_VERSION to $NEW_VERSION"
       git push -u "https://$GITHUB_ACTOR:$TOKEN@github.com/$GITHUB_REPOSITORY.git" $BRANCH_NAME

--- a/dependency-check.sh
+++ b/dependency-check.sh
@@ -40,7 +40,7 @@ for upgrade in $UPGRADES; do
 
   # If we're performing a batch update, reuse the branch name
   # Otherwise, create branch names for each unique update
-  if [ $BATCH = 'true' ]; then
+  if [ "$BATCH" == "true" ]; then
     BRANCH_NAME="dependencies/clojure/${UPDATE_TIME}"
   else
     BRANCH_NAME="dependencies/clojure/$DEP_NAME-$NEW_VERSION"
@@ -62,7 +62,7 @@ for upgrade in $UPGRADES; do
     git push -u "https://$GITHUB_ACTOR:$TOKEN@github.com/$GITHUB_REPOSITORY.git" $BRANCH_NAME
 
     # We only create pull requests per dependency in non-batch mode
-    if [$BATCH != 'true']; then
+    if [ "$BATCH" != "true" ]; then
       gh pr create --fill --head $BRANCH_NAME --base $BRANCH
     fi
 
@@ -73,7 +73,7 @@ for upgrade in $UPGRADES; do
 done
 
 # Once all updates have been made, open the pull request for batch mode
-if [$BATCH = 'true']; then
+if [ "$BATCH" == "true" ]; then
   git checkout $BRANCH_NAME
   gh pr create --fill --head $BRANCH_NAME --base $BRANCH
 fi


### PR DESCRIPTION
Changes proposed in this merge request:
- Additions: Dependency update commit messages now link to the github diff between the old and new version.
- Updates: Use antq to perform dependency updates instead of sed. 
- Deletions: None

### Pre-merge Checklist
- [x] Update documentation
- [x] Update CHANGELOG and increment version
