### PR TITLE
doc: fix inaccurate documentation of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ jobs:
       with:
         github-token: ${{ secrets.github_token }}
         git-username: nnichols
-        skips: "pom"
-        batch: "true"
+        skips: "pom boot"
+        batch: true
         branch: "main"
         directories: "cli web"
 ```


### PR DESCRIPTION
- batch needs true or false without quotation mark or it fails with `A sequence was not expected`
- showing how to skip multiple build tools because it is a string of multiple items not a list

Changes proposed in this merge request:
- Updates: Documentation