### PR TITLE
pin dependency image to SHA256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nnichols/clojure-dependency-update-action
+FROM nnichols/clojure-dependency-update-action@sha256:06c47e969b386796a09f296d80af705c1d8b578cae41ebe018b08a0f657d4081
 
 COPY dependency-check.sh /dependency-check.sh
 


### PR DESCRIPTION
Docker-based GitHub actions are built every time [1]. This means that if the `nnichols/clojure-dependency-update-action:latest` image is compromised, it could result in arbitrary code execution. Pinning the image to its current SHA256 digest [2] removes that attack vector.

[1] https://docs.github.com/en/actions/creating-actions/about-custom-actions#docker-container-actions
[2] https://hub.docker.com/layers/nnichols/clojure-dependency-update-action/latest/images/sha256-06c47e969b386796a09f296d80af705c1d8b578cae41ebe018b08a0f657d4081?context=explore

# Proposed Changes

- Additions:
- Updates: Dockerfile FROM usage
- Deletions:

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
